### PR TITLE
Variables in Repo directory and resizable repo/clone dialogs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,6 @@
 .classpath
 .project
 .settings/
+.idea/
+pdi-git-plugin.iml
+

--- a/src/main/java/org/pentaho/di/git/spoon/GitController.java
+++ b/src/main/java/org/pentaho/di/git/spoon/GitController.java
@@ -16,15 +16,7 @@
 
 package org.pentaho.di.git.spoon;
 
-import java.io.File;
-import java.io.InputStream;
-import java.lang.reflect.InvocationTargetException;
-import java.util.ArrayList;
-import java.util.List;
-import java.util.function.Consumer;
-import java.util.stream.Collectors;
-
-import javassist.compiler.ast.Variable;
+import com.google.common.annotations.VisibleForTesting;
 import org.apache.commons.collections.CollectionUtils;
 import org.apache.commons.io.FileUtils;
 import org.apache.commons.io.FilenameUtils;
@@ -50,10 +42,10 @@ import org.pentaho.di.core.variables.VariableSpace;
 import org.pentaho.di.core.variables.Variables;
 import org.pentaho.di.git.spoon.dialog.DeleteBranchDialog;
 import org.pentaho.di.git.spoon.model.GitRepository;
+import org.pentaho.di.git.spoon.model.IVCS;
 import org.pentaho.di.git.spoon.model.SVN;
 import org.pentaho.di.git.spoon.model.UIFile;
 import org.pentaho.di.git.spoon.model.UIGit;
-import org.pentaho.di.git.spoon.model.IVCS;
 import org.pentaho.di.i18n.BaseMessages;
 import org.pentaho.di.job.JobMeta;
 import org.pentaho.di.trans.TransMeta;
@@ -84,7 +76,13 @@ import org.pentaho.ui.xul.swt.tags.SwtTreeItem;
 import org.pentaho.ui.xul.util.XulDialogCallback.Status;
 import org.pentaho.ui.xul.util.XulDialogLambdaCallback;
 
-import com.google.common.annotations.VisibleForTesting;
+import java.io.File;
+import java.io.InputStream;
+import java.lang.reflect.InvocationTargetException;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.function.Consumer;
+import java.util.stream.Collectors;
 
 public class GitController extends AbstractXulEventHandler {
 

--- a/src/main/java/org/pentaho/di/git/spoon/GitController.java
+++ b/src/main/java/org/pentaho/di/git/spoon/GitController.java
@@ -24,6 +24,7 @@ import java.util.List;
 import java.util.function.Consumer;
 import java.util.stream.Collectors;
 
+import javassist.compiler.ast.Variable;
 import org.apache.commons.collections.CollectionUtils;
 import org.apache.commons.io.FileUtils;
 import org.apache.commons.io.FilenameUtils;
@@ -45,6 +46,8 @@ import org.pentaho.di.base.AbstractMeta;
 import org.pentaho.di.core.Const;
 import org.pentaho.di.core.EngineMetaInterface;
 import org.pentaho.di.core.exception.KettleXMLException;
+import org.pentaho.di.core.variables.VariableSpace;
+import org.pentaho.di.core.variables.Variables;
 import org.pentaho.di.git.spoon.dialog.DeleteBranchDialog;
 import org.pentaho.di.git.spoon.model.GitRepository;
 import org.pentaho.di.git.spoon.model.SVN;
@@ -231,7 +234,11 @@ public class GitController extends AbstractXulEventHandler {
   }
 
   public void openGit( GitRepository repo ) {
-    String baseDirectory = repo.getDirectory();
+    VariableSpace space = new Variables(  );
+    space.initializeVariablesFrom( null );
+
+    String baseDirectory = space.environmentSubstitute( repo.getDirectory() );
+
     try {
       if ( repo.getType() == null || repo.getType().equals( IVCS.GIT ) ) {
         vcs = new UIGit();

--- a/src/main/java/org/pentaho/di/git/spoon/GitController.java
+++ b/src/main/java/org/pentaho/di/git/spoon/GitController.java
@@ -232,10 +232,8 @@ public class GitController extends AbstractXulEventHandler {
   }
 
   public void openGit( GitRepository repo ) {
-    VariableSpace space = new Variables(  );
-    space.initializeVariablesFrom( null );
 
-    String baseDirectory = space.environmentSubstitute( repo.getDirectory() );
+    String baseDirectory = repo.getActualDirectory();
 
     try {
       if ( repo.getType() == null || repo.getType().equals( IVCS.GIT ) ) {
@@ -504,7 +502,7 @@ public class GitController extends AbstractXulEventHandler {
 
   public void setPath( GitRepository repo ) {
     this.path = repo.getName();
-    ( (Control) document.getElementById( "path" ).getManagedObject() ).setToolTipText( repo.getDirectory() );
+    ( (Control) document.getElementById( "path" ).getManagedObject() ).setToolTipText( repo.getActualDirectory() );
     firePropertyChange( "path", null, path );
     ( (SwtElement) document.getElementById( "path" ).getParent() ).layout();
   }

--- a/src/main/java/org/pentaho/di/git/spoon/GitPerspective.java
+++ b/src/main/java/org/pentaho/di/git/spoon/GitPerspective.java
@@ -34,6 +34,7 @@ import org.pentaho.di.ui.spoon.SpoonPerspectiveImageProvider;
 import org.pentaho.di.ui.spoon.SpoonPerspectiveListener;
 import org.pentaho.di.ui.spoon.XulSpoonResourceBundle;
 import org.pentaho.di.ui.xul.KettleXulLoader;
+import org.pentaho.metastore.api.exceptions.MetaStoreException;
 import org.pentaho.ui.xul.XulDomContainer;
 import org.pentaho.ui.xul.XulException;
 import org.pentaho.ui.xul.XulOverlay;
@@ -200,5 +201,15 @@ public class GitPerspective implements SpoonPerspectiveImageProvider {
 
   public GitController getController() {
     return this.controller;
+  }
+
+  /**
+   * This method is made as convenience for other plugins so that they can directly open a repository
+   * by simply getting a hold of the main plugin class.
+   *
+   * @param repositoryName
+   */
+  public void openRepository(String repositoryName) throws MetaStoreException {
+    gitSpoonMenuController.openRepo( repositoryName );
   }
 }

--- a/src/main/java/org/pentaho/di/git/spoon/GitPerspective.java
+++ b/src/main/java/org/pentaho/di/git/spoon/GitPerspective.java
@@ -212,4 +212,14 @@ public class GitPerspective implements SpoonPerspectiveImageProvider {
   public void openRepository(String repositoryName) throws MetaStoreException {
     gitSpoonMenuController.openRepo( repositoryName );
   }
+
+  /**
+   * This method is made as convenience for other plugins so that they see which GitSpoon repositories are defined.
+   *
+   * @return The list of git repository names
+   * @throws MetaStoreException
+   */
+  public List<String> getRepoNames() throws MetaStoreException {
+    return gitSpoonMenuController.getRepoNames();
+  }
 }

--- a/src/main/java/org/pentaho/di/git/spoon/GitSpoonMenuController.java
+++ b/src/main/java/org/pentaho/di/git/spoon/GitSpoonMenuController.java
@@ -31,6 +31,7 @@ import org.pentaho.di.git.spoon.model.SVN;
 import org.pentaho.di.git.spoon.model.UIGit;
 import org.pentaho.di.i18n.BaseMessages;
 import org.pentaho.di.ui.core.dialog.EnterSelectionDialog;
+import org.pentaho.di.ui.core.dialog.ErrorDialog;
 import org.pentaho.di.ui.spoon.ISpoonMenuController;
 import org.pentaho.di.ui.spoon.Spoon;
 import org.pentaho.metastore.api.IMetaStore;
@@ -58,8 +59,8 @@ public class GitSpoonMenuController extends AbstractXulEventHandler implements I
   }
 
   public void openRepo() {
-    MetaStoreFactory<GitRepository> repoFactory = getRepoFactory();
 
+    MetaStoreFactory<GitRepository> repoFactory = getRepoFactory();
     try {
       List<String> names = repoFactory.getElementNames();
       Collections.sort( names );
@@ -69,11 +70,28 @@ public class GitSpoonMenuController extends AbstractXulEventHandler implements I
       if ( name == null ) {
         return;
       }
-      GitRepository repo = repoFactory.loadElement( name );
-      gitController.openGit( repo );
+
+      openRepo( repoFactory, name );
     } catch ( Exception e ) {
-      e.printStackTrace();
+      new ErrorDialog( Spoon.getInstance().getShell(), "Error", "Error opening Git Reposisory", e );
     }
+  }
+
+  private void openRepo( MetaStoreFactory<GitRepository> repoFactory, String repositoryName ) throws MetaStoreException {
+    GitRepository repo = repoFactory.loadElement( repositoryName );
+    gitController.openGit( repo );
+  }
+
+  /**
+   * Open a repository with a given name.
+   * Convenience method so we can call this method from other places/plugins.
+   *
+   * @param repositoryName The name of the repository to open
+   * @throws MetaStoreException
+   */
+  public void openRepo( String repositoryName ) throws MetaStoreException {
+    MetaStoreFactory<GitRepository> repoFactory = getRepoFactory();
+    openRepo(repoFactory, repositoryName);
   }
 
   public Boolean isRepoEmpty() throws MetaStoreException {

--- a/src/main/java/org/pentaho/di/git/spoon/GitSpoonMenuController.java
+++ b/src/main/java/org/pentaho/di/git/spoon/GitSpoonMenuController.java
@@ -94,6 +94,16 @@ public class GitSpoonMenuController extends AbstractXulEventHandler implements I
     openRepo(repoFactory, repositoryName);
   }
 
+  /**
+   * Allow other plugins to see which Git repositories are defined.
+   * @return A list of Git Reposisoty names
+   * @throws MetaStoreException
+   */
+  public List<String> getRepoNames() throws MetaStoreException {
+    MetaStoreFactory<GitRepository> repoFactory = getRepoFactory();
+    return repoFactory.getElementNames();
+  }
+
   public Boolean isRepoEmpty() throws MetaStoreException {
     return getRepoFactory().getElementNames().isEmpty();
   }

--- a/src/main/java/org/pentaho/di/git/spoon/GitSpoonMenuController.java
+++ b/src/main/java/org/pentaho/di/git/spoon/GitSpoonMenuController.java
@@ -146,13 +146,12 @@ public class GitSpoonMenuController extends AbstractXulEventHandler implements I
     GitRepository repo = new GitRepository();
     CloneRepositoryDialog dialog = getCloneRepositoryDialog( repo );
     if ( dialog.open() == Window.OK ) {
-      if ( !new File( dialog.getDirectory() ).exists() ) {
-        showMessageBox( "Error", dialog.getDirectory() + " does not exist" );
+      if ( !new File( repo.getActualDirectory() ).exists() ) {
+        showMessageBox( "Error", repo.getActualDirectory() + " does not exist" );
         return;
       }
       String url = dialog.getURL();
-      String directory = null;
-      directory = dialog.getDirectory() + File.separator + dialog.getCloneAs();
+      String directory = repo.getDirectory();
       IVCS vcs = getVCS( repo );
       vcs.setShell( getShell() );
       if ( vcs.cloneRepo( directory, url ) ) {

--- a/src/main/java/org/pentaho/di/git/spoon/GitSpoonMenuController.java
+++ b/src/main/java/org/pentaho/di/git/spoon/GitSpoonMenuController.java
@@ -151,7 +151,7 @@ public class GitSpoonMenuController extends AbstractXulEventHandler implements I
         return;
       }
       String url = dialog.getURL();
-      String directory = repo.getDirectory();
+      String directory = repo.getActualDirectory();
       IVCS vcs = getVCS( repo );
       vcs.setShell( getShell() );
       if ( vcs.cloneRepo( directory, url ) ) {

--- a/src/main/java/org/pentaho/di/git/spoon/dialog/CloneRepositoryDialog.java
+++ b/src/main/java/org/pentaho/di/git/spoon/dialog/CloneRepositoryDialog.java
@@ -21,6 +21,8 @@ import java.net.URISyntaxException;
 
 import org.eclipse.jgit.transport.URIish;
 import org.eclipse.swt.SWT;
+import org.eclipse.swt.layout.FormAttachment;
+import org.eclipse.swt.layout.FormData;
 import org.eclipse.swt.layout.GridData;
 import org.eclipse.swt.layout.GridLayout;
 import org.eclipse.swt.widgets.Composite;
@@ -41,24 +43,43 @@ public class CloneRepositoryDialog extends EditRepositoryDialog {
     super( parentShell, repo );
   }
 
-  @Override
-  protected Control createDialogArea( Composite parent ) {
-    Composite comp = (Composite) super.createDialogArea( parent );
+  public int open() {
+    createShell("Clone Repository");
+    Control lastControl = addRepositoryControls(shell, centerPct, margin);
 
-    GridLayout layout = (GridLayout) comp.getLayout();
-    layout.numColumns = 3;
-
-    Label urlLabel = new Label( comp, SWT.RIGHT );
+    // URL
+    //
+    Label urlLabel = new Label( shell, SWT.RIGHT );
     urlLabel.setText( "Source URL: " );
-    urlLabel.setLayoutData( new GridData( GridData.END, GridData.CENTER, false, false ) );
-    urlText = new Text( comp, SWT.SINGLE | SWT.BORDER );
-    urlText.setLayoutData( new GridData( GridData.FILL, GridData.CENTER, true, false, 2, 1 ) );
+    FormData fdUrlLabel = new FormData();
+    fdUrlLabel.left = new FormAttachment( 0, 0 );
+    fdUrlLabel.right = new FormAttachment( centerPct, 0 );
+    fdUrlLabel.top = new FormAttachment( lastControl, margin );
+    urlLabel.setLayoutData( fdUrlLabel );
 
-    Label cloneAsLabel = new Label( comp, SWT.RIGHT );
+    urlText = new Text( shell, SWT.SINGLE | SWT.BORDER );
+    FormData fdUrlText = new FormData();
+    fdUrlText.left = new FormAttachment( centerPct, margin );
+    fdUrlText.right = new FormAttachment( 100, 0 );
+    fdUrlText.top = new FormAttachment( urlLabel, 0, SWT.CENTER);
+    urlText.setLayoutData( fdUrlText );
+
+    // Clone As...
+    //
+    Label cloneAsLabel = new Label( shell, SWT.RIGHT );
     cloneAsLabel.setText( "Clone As: " );
-    cloneAsLabel.setLayoutData( new GridData( GridData.END, GridData.CENTER, false, false ) );
-    cloneAsText = new Text( comp, SWT.SINGLE | SWT.BORDER );
-    cloneAsText.setLayoutData( new GridData( GridData.FILL, GridData.CENTER, true, false, 2, 1 ) );
+    FormData fdCloneAsLabel = new FormData();
+    fdCloneAsLabel.left = new FormAttachment( 0, 0 );
+    fdCloneAsLabel.right = new FormAttachment( centerPct, 0 );
+    fdCloneAsLabel.top = new FormAttachment( lastControl, margin );
+    cloneAsLabel.setLayoutData( fdCloneAsLabel );
+
+    cloneAsText = new Text( shell, SWT.SINGLE | SWT.BORDER );
+    FormData fdCloneAsText = new FormData();
+    fdCloneAsText.left = new FormAttachment( centerPct, margin );
+    fdCloneAsText.right = new FormAttachment( 100, 0 );
+    fdCloneAsText.top = new FormAttachment( cloneAsLabel, 0, SWT.CENTER);
+    cloneAsText.setLayoutData( fdCloneAsText );
 
     urlText.addModifyListener( event -> {
       String url = ( (Text) event.widget ).getText();
@@ -67,26 +88,24 @@ public class CloneRepositoryDialog extends EditRepositoryDialog {
         uri = new URIish( url );
         cloneAsText.setText( uri.getHumanishName() );
       } catch ( URISyntaxException e ) {
-//        e.printStackTrace();
+        //        e.printStackTrace();
       }
     } );
-
-    return comp;
+    lastControl = cloneAsText;
+    
+    addButtonsManageShell(lastControl);
+    return returnValue;
   }
 
   @Override
-  protected void okPressed() {
+  public void ok() {
+    super.ok();
     url = urlText.getText();
     cloneAs = cloneAsText.getText();
-    super.okPressed();
-    repo.setDirectory( getDirectory() + File.separator + cloneAs );
+    repo.setDirectory( directory + File.separator + cloneAs );
   }
 
   public String getURL() {
     return url;
-  }
-
-  public String getCloneAs() {
-    return cloneAs;
   }
 }

--- a/src/main/java/org/pentaho/di/git/spoon/dialog/CloneRepositoryDialog.java
+++ b/src/main/java/org/pentaho/di/git/spoon/dialog/CloneRepositoryDialog.java
@@ -16,21 +16,18 @@
 
 package org.pentaho.di.git.spoon.dialog;
 
-import java.io.File;
-import java.net.URISyntaxException;
-
 import org.eclipse.jgit.transport.URIish;
 import org.eclipse.swt.SWT;
 import org.eclipse.swt.layout.FormAttachment;
 import org.eclipse.swt.layout.FormData;
-import org.eclipse.swt.layout.GridData;
-import org.eclipse.swt.layout.GridLayout;
-import org.eclipse.swt.widgets.Composite;
 import org.eclipse.swt.widgets.Control;
 import org.eclipse.swt.widgets.Label;
 import org.eclipse.swt.widgets.Shell;
 import org.eclipse.swt.widgets.Text;
 import org.pentaho.di.git.spoon.model.GitRepository;
+
+import java.io.File;
+import java.net.URISyntaxException;
 
 public class CloneRepositoryDialog extends EditRepositoryDialog {
 

--- a/src/main/java/org/pentaho/di/git/spoon/model/GitRepository.java
+++ b/src/main/java/org/pentaho/di/git/spoon/model/GitRepository.java
@@ -16,6 +16,8 @@
 
 package org.pentaho.di.git.spoon.model;
 
+import org.pentaho.di.core.variables.VariableSpace;
+import org.pentaho.di.core.variables.Variables;
 import org.pentaho.metastore.persist.MetaStoreAttribute;
 import org.pentaho.metastore.persist.MetaStoreElementType;
 
@@ -67,4 +69,12 @@ public class GitRepository {
   public void setType( String type ) {
     this.type = type;
   }
+
+
+  public String getActualDirectory() {
+    VariableSpace space = new Variables();
+    space.initializeVariablesFrom( null );
+    return space.environmentSubstitute( directory );
+  }
+
 }

--- a/src/main/java/org/pentaho/di/git/spoon/model/UIGit.java
+++ b/src/main/java/org/pentaho/di/git/spoon/model/UIGit.java
@@ -16,32 +16,15 @@
 
 package org.pentaho.di.git.spoon.model;
 
-import java.io.ByteArrayOutputStream;
-import java.io.File;
-import java.io.FileInputStream;
-import java.io.FileNotFoundException;
-import java.io.IOException;
-import java.io.InputStream;
-import java.net.URISyntaxException;
-import java.nio.file.StandardCopyOption;
-import java.util.ArrayList;
-import java.util.Date;
-import java.util.List;
-import java.util.Map.Entry;
-import java.util.Set;
-import java.util.stream.Collectors;
-
+import com.google.common.annotations.VisibleForTesting;
 import org.apache.commons.io.FilenameUtils;
 import org.eclipse.jface.window.Window;
 import org.eclipse.jgit.api.CloneCommand;
 import org.eclipse.jgit.api.DiffCommand;
-import org.eclipse.jgit.api.FetchCommand;
 import org.eclipse.jgit.api.Git;
 import org.eclipse.jgit.api.ListBranchCommand.ListMode;
 import org.eclipse.jgit.api.MergeResult;
 import org.eclipse.jgit.api.MergeResult.MergeStatus;
-import org.eclipse.jgit.api.PullCommand;
-import org.eclipse.jgit.api.PullResult;
 import org.eclipse.jgit.api.PushCommand;
 import org.eclipse.jgit.api.RemoteAddCommand;
 import org.eclipse.jgit.api.RemoteRemoveCommand;
@@ -50,9 +33,8 @@ import org.eclipse.jgit.api.RevertCommand;
 import org.eclipse.jgit.api.Status;
 import org.eclipse.jgit.api.errors.GitAPIException;
 import org.eclipse.jgit.api.errors.TransportException;
-import org.eclipse.jgit.diff.DiffEntry.ChangeType;
 import org.eclipse.jgit.diff.DiffEntry;
-import org.eclipse.jgit.diff.DiffFormatter;
+import org.eclipse.jgit.diff.DiffEntry.ChangeType;
 import org.eclipse.jgit.diff.RenameDetector;
 import org.eclipse.jgit.dircache.DirCacheIterator;
 import org.eclipse.jgit.errors.AmbiguousObjectException;
@@ -74,13 +56,11 @@ import org.eclipse.jgit.lib.RepositoryState;
 import org.eclipse.jgit.lib.StoredConfig;
 import org.eclipse.jgit.lib.UserConfig;
 import org.eclipse.jgit.merge.MergeStrategy;
-import org.eclipse.jgit.merge.ResolveMerger.MergeFailureReason;
 import org.eclipse.jgit.revwalk.RevCommit;
 import org.eclipse.jgit.revwalk.RevObject;
 import org.eclipse.jgit.revwalk.RevTree;
 import org.eclipse.jgit.revwalk.RevWalk;
 import org.eclipse.jgit.transport.CredentialsProvider;
-import org.eclipse.jgit.transport.FetchResult;
 import org.eclipse.jgit.transport.HttpTransport;
 import org.eclipse.jgit.transport.PushResult;
 import org.eclipse.jgit.transport.RefSpec;
@@ -108,7 +88,19 @@ import org.pentaho.di.ui.core.dialog.EnterSelectionDialog;
 import org.pentaho.di.ui.repository.pur.repositoryexplorer.model.UIRepositoryObjectRevision;
 import org.pentaho.di.ui.repository.pur.repositoryexplorer.model.UIRepositoryObjectRevisions;
 
-import com.google.common.annotations.VisibleForTesting;
+import java.io.ByteArrayOutputStream;
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.FileNotFoundException;
+import java.io.IOException;
+import java.io.InputStream;
+import java.net.URISyntaxException;
+import java.nio.file.StandardCopyOption;
+import java.util.ArrayList;
+import java.util.Date;
+import java.util.List;
+import java.util.Set;
+import java.util.stream.Collectors;
 
 public class UIGit extends VCS implements IVCS {
 

--- a/src/test/java/org/pentaho/di/git/spoon/GitSpoonMenuControllerTest.java
+++ b/src/test/java/org/pentaho/di/git/spoon/GitSpoonMenuControllerTest.java
@@ -69,15 +69,12 @@ public class GitSpoonMenuControllerTest extends RepositoryTestCase {
     when( cloneRepositoryDialog.open() ).thenReturn( Window.CANCEL );
 
     controller.cloneRepo();
-
-    verify( cloneRepositoryDialog, never() ).getDirectory();
   }
 
   @Test
   public void testCloneShouldSucceed() throws Exception {
     when( cloneRepositoryDialog.open() ).thenReturn( Window.OK );
     when( cloneRepositoryDialog.getURL() ).thenReturn( db.getDirectory().getPath() );
-    when( cloneRepositoryDialog.getDirectory() ).thenReturn( dstFolder.getRoot().getPath() );
     doReturn( true ).when( git ).cloneRepo( anyString(), anyString() );
 
     controller.cloneRepo();


### PR DESCRIPTION
This allows us to package up projects completely self-contained and auto-configured using ```kettle-environment``` by setting the repo directory to something like ```${ENVIRONMENT_HOME}```